### PR TITLE
Add net price as default attribute

### DIFF
--- a/src/Resources/views/tweakwise/product.xml.twig
+++ b/src/Resources/views/tweakwise/product.xml.twig
@@ -114,6 +114,16 @@
                         <value>{{ price.listPrice.price|round(2, 'common') }}</value>
                     </attribute>
                     {% endif %}
+                    {% if price.calculatedTaxes.count > 0 %}
+                        {% set netPrice = price.unitPrice %}
+                        {% for tax in price.calculatedTaxes %}
+                            {% set netPrice = netPrice - tax.tax %}
+                        {% endfor %}
+                        <attribute>
+                            <name>sw-price-net</name>
+                            <value>{{ netPrice|round(2, 'common') }}</value>
+                        </attribute>
+                    {% endif %}
                     <attribute>
                         <name>sw-avg-rating</name>
                         <value>{% if product.ratingAverage %}{{ product.ratingAverage }}{% endif %}</value>


### PR DESCRIPTION
As the net price and list price are usually used in the display of search results and product listings I think these should be included in the feed by default.

In the available data in the template there was no net price field available which is why I calculated it from the taxes.