### PR TITLE
Check if discount is actually present

### DIFF
--- a/src/Resources/views/tweakwise/product.xml.twig
+++ b/src/Resources/views/tweakwise/product.xml.twig
@@ -64,7 +64,7 @@
                     </attribute>
                     <attribute>
                         <name>sw-has-discount</name>
-                        <value>{% if price.listPrice %}true{% else %}false{% endif %}</value>
+                        <value>{% if price.listPrice and price.listPrice.price > price.unitPrice %}true{% else %}false{% endif %}</value>
                     </attribute>
                     <attribute>
                         <name>sw-is-topseller</name>


### PR DESCRIPTION
Quite often the list price is present but is the same as the current selling price. In this case there is no discount which is why I've added an extra check for this.