### PR TITLE
Remove setTwig call from TweakwiseSearchController

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -49,9 +49,6 @@
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
-            <call method="setTwig">
-                <argument type="service" id="twig"/>
-            </call>
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
         </service>
         <service id="RH\Tweakwise\Controller\AdminController" public="true">


### PR DESCRIPTION
Removed the call to setTwig in TweakwiseSearchController as it does not exist anymore. See https://github.com/shopware/shopware/blob/trunk/changelog/release-6-6-10-0/2024-11-26-deprecate-settwig-in-storefront-controller.md?plain=1