### PR TITLE
Update languageKey assignment with fallback

### DIFF
--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -2,7 +2,7 @@
 
 {% block layout_head_meta_tags %}
     {% set instanceKey = page.extensions.twConfiguration.instanceKey|escape %}
-    {% set languageKey = page.header.activeLanguage.translationCode.code|split('-')[0]|escape %}
+    {% set languageKey = (page.header.activeLanguage.translationCode.code ?? context.languageInfo.localeCode)|split('-')[0]|escape %}
     {% set wayOfSearch = page.extensions.twConfiguration.wayOfSearch|escape %}
 
     {{ parent() }}


### PR DESCRIPTION
In latest versions of SW 6.7 the page.header.activeLanguage is not available anymore, we need to use context.languageInfo