### PR TITLE
[BUGFIX] Extract last segment of category path for cid in ALP element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+**Fixed**
+- Prevented parent categories from showing up in the category filter on an Attribute Landing Page
+
 # 4.12.0
 
 **Added**

--- a/src/Resources/views/storefront/element/cms-element-tweakwise-attribute-landing-page.html.twig
+++ b/src/Resources/views/storefront/element/cms-element-tweakwise-attribute-landing-page.html.twig
@@ -103,7 +103,7 @@
     <script>
         window.addEventListener('twn.starter.ready', function () {
             const config = {
-                cid: "{{ element.config.category.value }}",
+                cid: "{{ element.config.category.value|split('-')|last }}",
                 output: "#tweakwise-alp",
                 {% if element.config.filterTemplate.value %}filterTemplateId: {{ element.config.filterTemplate.value }},{% endif %}
                 {% if element.config.sortTemplate.value %}sortingTemplateId: {{ element.config.sortTemplate.value }},{% endif %}


### PR DESCRIPTION
## Summary
- Backported a fix from the v5 branch (commit 20b84c3): the Attribute Landing Page element was passing the full category path as the Tweakwise `cid`, causing parent categories to leak into the category filter instead of just the selected category.
- Added an `Unreleased` changelog entry.

## Test plan
- [x] Configure an Attribute Landing Page CMS element on a nested category and verify only the selected category (not its parents) appears in the resulting category filter.