### PR TITLE
[TASK] Bump pinned Shopware CI version to fix broken Unit testing job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version: 'v6.6.10.18'
+          shopware-version: 'v6.6.10.21'
           php-version: 8.2
           env: test
           php-extensions: pcov


### PR DESCRIPTION
## Summary
- `test.yml` pinned `shopware-version: 'v6.6.10.18'` for the Unit testing job. That tag requires `dompdf/dompdf` exactly `3.1.4`, which is now blocked by Composer's security-advisory policy, so the "Setup Shopware" step fails before any plugin tests run.
- Bumped the pin to `v6.6.10.21`, which requires `dompdf/dompdf 3.1.6` and is unaffected.

## Test plan
- [ ] CI's "Unit testing" job should get past "Setup Shopware" and actually run the test suite.